### PR TITLE
add expat 

### DIFF
--- a/expat.xml
+++ b/expat.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" ?>
+<?xml-stylesheet type='text/xsl' href='interface.xsl'?>
+<interface uri="http://0install.de/feeds/expat.xml" xmlns="http://zero-install.sourceforge.net/2004/injector/interface" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://zero-install.sourceforge.net/2004/injector/interface http://0install.de/schema/injector/interface/interface.xsd http://0install.de/schema/desktop-integration/capabilities http://0install.de/schema/desktop-integration/capabilities/capabilities.xsd">
+  <name>Expat XML Parser</name>
+  <summary xml:lang="en">This is James Clark's Expat XML parser library in C.</summary>
+  <description xml:lang="en">It is a stream oriented parser that requires setting handlers to deal with the structure that the parser  discovers in the document.</description>
+  <category>Development</category>
+  <homepage>https://sourceforge.net/projects/expat/</homepage>
+  <implementation arch="Windows-*" id="sha1new=f5ad88fda73a6060204f72326a9a875fe21c525e" license="MIT/X Consortium License" released="2000-10-22" version="1.95.1">
+    <manifest-digest sha256new="KBPHRCHXWQYXNJTXGUMRFMJVUJJ3YAM4JCBAHLRGJSDBCM6LTQKA"/>
+    <archive extract="expat_win32bin_1_95_1" href="https://sourceforge.net/projects/expat/files/expat_win32/1.95.1/expat_win32bin_1_95_1.zip" size="119596" type="application/zip"/>
+  </implementation>
+  <implementation arch="Windows-*" id="1.95.1withdllrenamed" license="MIT/X Consortium License" released="2000-10-22" version="1.95.0">
+    <manifest-digest sha256new="MCUPVDSVDVI5DJ63BTG2MI53FG23LX2CL6SDSKCNZO6RUZOLWTCQ"/>
+    <recipe>
+      <copy-from dest="libexpat.dll" id="sha1new=f5ad88fda73a6060204f72326a9a875fe21c525e" source="expat_1_95_1.dll"/>
+    </recipe>
+  </implementation>
+</interface>

--- a/expat.xml
+++ b/expat.xml
@@ -9,6 +9,7 @@
   <implementation arch="Windows-*" id="sha1new=f5ad88fda73a6060204f72326a9a875fe21c525e" license="MIT/X Consortium License" released="2000-10-22" version="1.95.1">
     <manifest-digest sha256new="KBPHRCHXWQYXNJTXGUMRFMJVUJJ3YAM4JCBAHLRGJSDBCM6LTQKA"/>
     <archive extract="expat_win32bin_1_95_1" href="https://sourceforge.net/projects/expat/files/expat_win32/1.95.1/expat_win32bin_1_95_1.zip" size="119596" type="application/zip"/>
+    <archive extract="expat_win32bin_1_95_1" href="https://github.com/libexpat/libexpat/releases/download/R_1_95_1/expat_win32bin_1_95_1.zip?raw=true" size="119596" type="application/zip"/>
   </implementation>
   <implementation arch="Windows-*" id="1.95.1withdllrenamed" license="MIT/X Consortium License" released="2000-10-22" version="1.95.0">
     <manifest-digest sha256new="MCUPVDSVDVI5DJ63BTG2MI53FG23LX2CL6SDSKCNZO6RUZOLWTCQ"/>


### PR DESCRIPTION
This is needed as a gnuwin32 gettext dependency in the xgettext command

gettext expects a different file name so I have a second implementation that copies from the first to rename it.

gettext is needed by 
attr, bison, coreutils, cpio, dehtml, deroff, diction, diffutils, findutils, gcal, help2man, jwhois, libiconv, make, ntfsprogs, sed, sharutils, tre and util-linux-ng 

This is the only version on the source forge or github sites packaged as a zip. The others are all windows executable installers that 0install cant treat as archives.
support for #3 